### PR TITLE
feat(o3dpc_to_rospc): add argument to o3dpc_to_rospc function

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ covert ros point cloud to open3d point cloud
 #### o3dpc\_to\_rospc
 
 ```python
-o3dpc_to_rospc(o3dpc, frame_id=None)
+o3dpc_to_rospc(o3dpc, frame_id=None, stamp=None)
 ```
 
 convert open3d point cloud to ros point cloud
@@ -311,6 +311,7 @@ convert open3d point cloud to ros point cloud
 
 - `o3dpc` _open3d.geometry.PointCloud_ - open3d point cloud
 - `frame_id` _string_ - frame id of ros point cloud header
+- `stamp` _rospy.Time_ - time stamp of ros point cloud header
 
 **Returns**:
 

--- a/open3d_ros_helper/open3d_ros_helper.py
+++ b/open3d_ros_helper/open3d_ros_helper.py
@@ -288,11 +288,12 @@ def rospc_to_o3dpc(rospc, remove_nans=False):
 BIT_MOVE_16 = 2**16
 BIT_MOVE_8 = 2**8
 
-def o3dpc_to_rospc(o3dpc, frame_id=None):
+def o3dpc_to_rospc(o3dpc, frame_id=None, stamp=None):
     """ convert open3d point cloud to ros point cloud
-    Args: 
+    Args:
         o3dpc (open3d.geometry.PointCloud): open3d point cloud
         frame_id (string): frame id of ros point cloud header
+        stamp (rospy.Time): time stamp of ros point cloud header
     Returns:
         rospc (sensor.msg.PointCloud2): ros point cloud message
     """
@@ -330,7 +331,10 @@ def o3dpc_to_rospc(o3dpc, frame_id=None):
     if frame_id is not None:
         rospc.header.frame_id = frame_id
 
-    rospc.header.stamp = rospy.Time.now()
+    if stamp is None:
+        rospc.header.stamp = rospy.Time.now()
+    else:
+        rospc.header.stamp = stamp
     rospc.height = 1
     rospc.width = n_points
     rospc.fields = []


### PR DESCRIPTION
The o3dpc_to_rospc function can only be used if the roscore is running in real time.
In case you want to convert the pcd read from rosbag, I add stamp argument to o3dpc_to_rospc function