### PR TITLE
Numpy reshaping added to rospc_to_o3dpc

### DIFF
--- a/open3d_ros_helper/open3d_ros_helper.py
+++ b/open3d_ros_helper/open3d_ros_helper.py
@@ -271,7 +271,8 @@ def rospc_to_o3dpc(rospc, remove_nans=False):
     cloud_npy[...,1] = cloud_array['y']
     cloud_npy[...,2] = cloud_array['z']
     o3dpc = open3d.geometry.PointCloud()
-    o3dpc.points = open3d.utility.Vector3dVector(cloud_npy[:, :3])
+    cloud_npy = np.reshape(cloud_npy[:, :, :3], [-1, 3], 'F')
+    o3dpc.points = open3d.utility.Vector3dVector(cloud_npy)
 
     if is_rgb:
         rgb_npy = cloud_array['rgb']


### PR DESCRIPTION
open3d.utility.Vector3dVectory expects an input of shape (n, 3) http://www.open3d.org/docs/release/python_api/open3d.utility.Vector3dVector.html#open3d-utility-vector3dvector

Tested this locally and it works. Was giving a "bad callback" runtime error before the change.