### PR TITLE
cloud_array ravel added to rospc_to_o3dpc

### DIFF
--- a/open3d_ros_helper/open3d_ros_helper.py
+++ b/open3d_ros_helper/open3d_ros_helper.py
@@ -258,7 +258,7 @@ def rospc_to_o3dpc(rospc, remove_nans=False):
     """
     field_names = [field.name for field in rospc.fields]
     is_rgb = 'rgb' in field_names
-    cloud_array = ros_numpy.point_cloud2.pointcloud2_to_array(rospc)
+    cloud_array = ros_numpy.point_cloud2.pointcloud2_to_array(rospc).ravel()
     if remove_nans:
         mask = np.isfinite(cloud_array['x']) & np.isfinite(cloud_array['y']) & np.isfinite(cloud_array['z'])
         cloud_array = cloud_array[mask]


### PR DESCRIPTION
Same problem as in #2, but with o3dpc.colors. 
Line 264 changes the array shape to the correct format, so the bug doesn't appear if remove_nans is True. However, if remove_nans is False, and the cloud contains RGB values, the cloud_array has the wrong shape. That leads to rgb_npy having the wrong shape too, and a Runtime Error in line 288. Adding .ravel() to line 261 should do the trick. 
