### PR TITLE
Replace np.float to be compatible with newer NumPy versions

### DIFF
--- a/open3d_ros_helper/open3d_ros_helper.py
+++ b/open3d_ros_helper/open3d_ros_helper.py
@@ -249,43 +249,42 @@ convert_rgbUint32_to_tuple = lambda rgb_uint32: (
 )
 
 def rospc_to_o3dpc(rospc, remove_nans=False):
-    """ covert ros point cloud to open3d point cloud
-    Args: 
-        rospc (sensor.msg.PointCloud2): ros point cloud message
-        remove_nans (bool): if true, ignore the NaN points
-    Returns: 
-        o3dpc (open3d.geometry.PointCloud): open3d point cloud
-    """
-    field_names = [field.name for field in rospc.fields]
-    is_rgb = 'rgb' in field_names
-    cloud_array = ros_numpy.point_cloud2.pointcloud2_to_array(rospc).ravel()
-    if remove_nans:
-        mask = np.isfinite(cloud_array['x']) & np.isfinite(cloud_array['y']) & np.isfinite(cloud_array['z'])
-        cloud_array = cloud_array[mask]
-    if is_rgb:
-        cloud_npy = np.zeros(cloud_array.shape + (4,), dtype=float)
-    else: 
-        cloud_npy = np.zeros(cloud_array.shape + (3,), dtype=float)
+    """ Convert ROS PointCloud2 to Open3D PointCloud
     
-    cloud_npy[...,0] = cloud_array['x']
-    cloud_npy[...,1] = cloud_array['y']
-    cloud_npy[...,2] = cloud_array['z']
+    Args: 
+        rospc (sensor.msg.PointCloud2): ROS PointCloud2 message
+        remove_nans (bool): If true, ignore the NaN points
+    
+    Returns: 
+        o3dpc (open3d.geometry.PointCloud): Open3D PointCloud
+    """
+    cloud_array = ros_numpy.point_cloud2.pointcloud2_to_array(rospc).ravel()
+
+    if remove_nans:
+        # Remove NaN values
+        mask = np.isfinite(cloud_array['x']) & \
+               np.isfinite(cloud_array['y']) & \
+               np.isfinite(cloud_array['z'])
+        cloud_array = cloud_array[mask]
+
+    # Initialize Open3D PointCloud
     o3dpc = open3d.geometry.PointCloud()
 
-    if len(np.shape(cloud_npy)) == 3:
-        cloud_npy = np.reshape(cloud_npy[:, :, :3], [-1, 3], 'F')
-    o3dpc.points = open3d.utility.Vector3dVector(cloud_npy[:, :3])
+    # Assign points to Open3d PCD
+    # Vector3dVector is optimized for numpy array with float64 datatype using memory mapping.
+    o3dpc.points = open3d.utility.Vector3dVector(np.c_[cloud_array['x'], 
+                                                       cloud_array['y'], 
+                                                       cloud_array['z']].astype(np.float64))  
 
-    if is_rgb:
-        rgb_npy = cloud_array['rgb']
-        rgb_npy.dtype = np.uint32
-        r = np.asarray((rgb_npy >> 16) & 255, dtype=np.uint8)
-        g = np.asarray((rgb_npy >> 8) & 255, dtype=np.uint8)
-        b = np.asarray(rgb_npy & 255, dtype=np.uint8)
-        rgb_npy = np.asarray([r, g, b])
-        rgb_npy = rgb_npy.astype(float)/255
-        rgb_npy = np.swapaxes(rgb_npy, 0, 1)
-        o3dpc.colors = open3d.utility.Vector3dVector(rgb_npy)
+    # If RGB information is available
+    if 'rgb' in cloud_array.dtype.names:
+        # Extract RGB values
+        rgb_npy = cloud_array['rgb'].view(dtype=np.uint32)
+        o3dpc.colors = open3d.utility.Vector3dVector(np.c_[(rgb_npy >> 16) & 255,        # Red
+                                                           (rgb_npy >> 8) & 255,         # Green
+                                                           (rgb_npy & 255)               # Blue
+                                                           ].astype(np.float64) / 255.)
+
     return o3dpc
 
 BIT_MOVE_16 = 2**16


### PR DESCRIPTION
The datatype np.float was removed from newer NumPy versions. I replaced it with np.float64 to use open3d-ros-helpers with ROS Noetic. I chose np.float64 because the function open3d.utility.Vector3dVector was optimized for this datatype. I also rewrote the function rospc_to_o3dpc to improve performance. 